### PR TITLE
Update heading for class-specific overview section to “Class Safety”

### DIFF
--- a/class-handouts/class-laser_101-basic_operation.typ
+++ b/class-handouts/class-laser_101-basic_operation.typ
@@ -51,7 +51,7 @@ After this class, you will be able to:
   - Handle emergency situations
   - Choose appropriate materials for your projects
 
-== Safety
+== Class Safety
   
   // Important safety notes for this particular class
   

--- a/class-handouts/class-laser_114-custom_wood_boxes.typ
+++ b/class-handouts/class-laser_114-custom_wood_boxes.typ
@@ -45,7 +45,7 @@ After this class, you will be able to:
   - Choose appropriate materials for your projects
   - Make and assemble a box
 
-== Safety
+== Class Safety
   
   // Important safety notes for this particular class
   

--- a/class-handouts/class-metal_101-shop_basics.typ
+++ b/class-handouts/class-metal_101-shop_basics.typ
@@ -39,7 +39,7 @@ Welcome to the Introduction to Metalworking class at Protohaven!
 
 #pagebreak()
 
-= Metalworking Safety
+= Class Safety
 
 Do not work in the metal shop wearing anything that could end up pulling you into a machine. Do not wear:
 

--- a/class-handouts/class-welding_101-basic_welding_skills.typ
+++ b/class-handouts/class-welding_101-basic_welding_skills.typ
@@ -32,7 +32,7 @@ Welcome to the Basic Welding Skills class at Protohaven!
 #pagebreak()
 
 
-= Safety
+= Class Safety
 
 // Important safety notes for this particular class
 

--- a/class-handouts/class-wood_101-shop_basics.typ
+++ b/class-handouts/class-wood_101-shop_basics.typ
@@ -30,7 +30,7 @@ Welcome to the Woodshop Basic Equipment Clearance class at Protohaven!
 #pagebreak()
 
 
-= Safety
+= Class Safety
 
 // Important safety notes for this particular class
 

--- a/class-handouts/class-wood_103-millwork.typ
+++ b/class-handouts/class-wood_103-millwork.typ
@@ -32,7 +32,7 @@ Welcome to the Millwork and Joinery class at Protohaven!
 
 #pagebreak()
 
-= Millwork and Joinery Safety
+= Class Safety
 
 - Always use eye protection.\
   _The machines covered in this class can cause pieces of wood to move unpredictably, and at high speed._

--- a/class-handouts/class-wood_104-wood_lathe.typ
+++ b/class-handouts/class-wood_104-wood_lathe.typ
@@ -31,7 +31,7 @@ Welcome to the Introduction to Lathe class at Protohaven!
 
 #pagebreak()
 
-= Safety
+= Class Safety
 
 - Use a full face shield (Safety glasses at a minimum) whenever the lathe is turned on.
 - Tie back long hair, do not wear gloves, and avoid loose clothing or objects that may catch on rotating parts or accessories.

--- a/class-handouts/class-wood_111-cutting_board.typ
+++ b/class-handouts/class-wood_111-cutting_board.typ
@@ -23,7 +23,7 @@ Welcome to the MUMBLE class at Protohaven!
 
 #pagebreak()
 
-= Safety
+= Class Safety
 
 - Important
 - Safety

--- a/class-handouts/class-wood_115-woodturning.typ
+++ b/class-handouts/class-wood_115-woodturning.typ
@@ -20,7 +20,7 @@ Welcome to the wood turning class at Protohaven!
 
 #pagebreak()
 
-= Woodturning Safety
+= Class Safety
 
 - Use a full face shield (Safety glasses at a minimum) whenever the lathe is turned on.
 - Tie back long hair, do not wear gloves, and avoid loose clothing or objects that may catch on rotating parts or accessories.

--- a/meta-templates/class-NAME.typ
+++ b/meta-templates/class-NAME.typ
@@ -1,7 +1,5 @@
 
-#import "/meta-environments/env-templates.typ": *
-
-#import "./glossary/glossary_terms.typ": *
+#import "/meta-environments/class_handouts.typ": *
 
 #show: doc => class_handout(
   title: "Class MUMBLE",
@@ -31,8 +29,7 @@ Welcome to the Introduction to Lathe class at Protohaven!
 
 #pagebreak()
 
-
-= Safety
+= Class Safety
 
 // Important safety notes for this particular class
 


### PR DESCRIPTION
Updates across all of the class handouts to make the label for the safety section for the class "Class Safety" to disambiguate it from the safety sections for the individual tools. This is also a better signal for the _type_ of safety content in  this section: an overview and any particular note that is critically important for the students to see for this particular class.